### PR TITLE
Add Github Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+# Pacifica Software Request
+
+## Issue Type
+
+Please describe what kind of request this is. Some valid options
+might be one of the following:
+
+ * New Repository
+ * General Inquiry
+ * Architecture/Design
+ * Community
+ * Documentation
+
+## Discussion
+
+Please describe what you are trying to find information about or
+what you are proposing for changes. Keep in mind this may not be
+the final resting place for your issue. Pacifica is trying to
+handle many different repositories with different purposes. Your
+issue may end up in several different places to be resolved.


### PR DESCRIPTION
This adds a general issue template to appeal to many different
kinds of inquiries to Pacifica. This should hopefully get users
to think about the kind of questions they have and then some
space to put their questions.

Signed-off-by: David Brown <dmlb2000@gmail.com>